### PR TITLE
Fix landing links in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,8 @@ The APIs in this document are organized by the feature, or group of features, th
 
 * [Hardware inputs and outputs](APIs/io/inputs_outputs.md): analog, digital, bus, port, PwmOut and interrupts.
 * [Digital interfaces and USB](APIs/interfaces/interfaces.md): serial, SPI, I2C, CAN and USB.
-* [Networking and communication](APIs/communication/communication.md): network stack, BLE, Ethernet, WiFi and radio. 
+* [Networking and communication](APIs/communication/network_sockets.md): network stack, BLE, Ethernet, WiFi and radio. 
 * [Device and networking security](APIs/security/security.md): mbed uVisor and mbed TLS.
-* [Task management](APIs/tasks/tasks.md): timers and RTOS.
-* [Memory and file system](APIs/memory_files/memory_files.md): memory and file systems.
+* [Task management](APIs/tasks/rtos.md): timers and RTOS.
 
 You can also view [the full doxygen](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.1.0/api/index.html).


### PR DESCRIPTION
Currently several links 404 in the first page users see for docs

Networking and communication -> communication/network_sockets.md
Task management -> tasks/rtos.md
Memory and filesystems x removed as there is no valid landing page

cc @iriark01