### PR TITLE
Added initial draft of documentation over filesystem/block devices

### DIFF
--- a/docs/APIs/storage/block_device.md
+++ b/docs/APIs/storage/block_device.md
@@ -1,0 +1,38 @@
+# Block Devices
+
+The block device API provides a simple interface for providing access to block-based storage. A block device can be used to back a full [filesystem](filesystem.md) or can be written to
+directly.
+
+The full C++ API can be found [here](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/BlockDevice.h)
+
+## Example
+
+Here is a quick example of a simple user of a block device:
+
+[SD block device example](https://github.com/ARMmbed/sd-driver/blob/master/README.md)
+
+## Block device operations
+
+A block device can perform three operations on block in a device:
+
+- Read a block from storage
+- Erase a block in storage
+- Program a block that has previously been erased
+
+Note: The state of an erased block is undefined. For some block devices, erase is a noop. If a deterministic value is required after an erase, this must be verified by the consumer of the block device.
+
+## Block sizes
+
+Some storage technologies have different sized blocks for different operations. For example, NAND flash can be read and programmed in 256 byte pages, but must be erased in 4Kbyte sectors.
+
+Block devices indicate their block sizes through the three `get_read_size`, `get_program_size`, and `get_erase_size` functions. The erase size must be a multiple of the program size, and the program size must be a multiple of the read size. Some devices may even have a read/program size of a single byte.
+
+As a rule of thumb, the erase size can be used for applications that use a single block size (for example, the FAT filesystem).
+
+## Example block devices
+
+- [SDBlockDevice](https://github.com/armmbed/sd-driver) - Block device for SD cards
+- [SPIFBlockDevice](https://github.com/armmbed/spiflash-driver) - Block device for NOR based SPI flash devices
+- [I2CEEBlockDevice](https://github.com/armmbed/i2ceeprom-driver) - Block device for EEPROM based I2C devices
+- [HeapBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h) - Block device backed by the heap for quick testing
+

--- a/docs/APIs/storage/block_device.md
+++ b/docs/APIs/storage/block_device.md
@@ -18,7 +18,7 @@ A block device can perform three operations on a block in a device:
 - Erase a block in storage.
 - Program a block that has previously been erased.
 
-Note: The state of an erased block is undefined. For some block devices, erase is a NOOP. If a deterministic value is required after an erase, the consumer of the block device must verify this.
+Note: The state of an erased block is undefined. NOR flash devices typically set an erased block to all 0xff, but for some block devices such as the SD card, erase is a NOOP. If a deterministic value is required after an erase, the consumer of the block device must verify this.
 
 ## Block sizes
 

--- a/docs/APIs/storage/block_device.md
+++ b/docs/APIs/storage/block_device.md
@@ -1,38 +1,36 @@
 # Block Devices
 
-The block device API provides a simple interface for providing access to block-based storage. A block device can be used to back a full [filesystem](filesystem.md) or can be written to
-directly.
+The block device API provides an interface for access to block-based storage. You can use a block device to back a full [file system](filesystem.md) or write to it directly.
 
-The full C++ API can be found [here](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/BlockDevice.h)
+You can find the full C++ API [here](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/BlockDevice.h).
 
 ## Example
 
-Here is a quick example of a simple user of a block device:
+Here is an example that uses a block device:
 
 [SD block device example](https://github.com/ARMmbed/sd-driver/blob/master/README.md)
 
 ## Block device operations
 
-A block device can perform three operations on block in a device:
+A block device can perform three operations on a block in a device:
 
-- Read a block from storage
-- Erase a block in storage
-- Program a block that has previously been erased
+- Read a block from storage.
+- Erase a block in storage.
+- Program a block that has previously been erased.
 
-Note: The state of an erased block is undefined. For some block devices, erase is a noop. If a deterministic value is required after an erase, this must be verified by the consumer of the block device.
+Note: The state of an erased block is undefined. For some block devices, erase is a NOOP. If a deterministic value is required after an erase, the consumer of the block device must verify this.
 
 ## Block sizes
 
-Some storage technologies have different sized blocks for different operations. For example, NAND flash can be read and programmed in 256 byte pages, but must be erased in 4Kbyte sectors.
+Some storage technologies have different sized blocks for different operations. For example, NAND flash can be read and programmed in 256-byte pages, but must be erased in 4-kilobyte sectors.
 
-Block devices indicate their block sizes through the three `get_read_size`, `get_program_size`, and `get_erase_size` functions. The erase size must be a multiple of the program size, and the program size must be a multiple of the read size. Some devices may even have a read/program size of a single byte.
+Block devices indicate their block sizes through the `get_read_size`, `get_program_size` and `get_erase_size` functions. The erase size must be a multiple of the program size, and the program size must be a multiple of the read size. Some devices may even have a read/program size of a single byte.
 
-As a rule of thumb, the erase size can be used for applications that use a single block size (for example, the FAT filesystem).
+As a rule of thumb, you can use the erase size for applications that use a single block size (for example, the FAT file system).
 
 ## Example block devices
 
-- [SDBlockDevice](https://github.com/armmbed/sd-driver) - Block device for SD cards
-- [SPIFBlockDevice](https://github.com/armmbed/spiflash-driver) - Block device for NOR based SPI flash devices
-- [I2CEEBlockDevice](https://github.com/armmbed/i2ceeprom-driver) - Block device for EEPROM based I2C devices
-- [HeapBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h) - Block device backed by the heap for quick testing
-
+- [SDBlockDevice](https://github.com/armmbed/sd-driver) - Block device for SD cards.
+- [SPIFBlockDevice](https://github.com/armmbed/spiflash-driver) - Block device for NOR-based SPI flash devices.
+- [I2CEEBlockDevice](https://github.com/armmbed/i2ceeprom-driver) - Block device for EEPROM-based I2C devices.
+- [HeapBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h) - Block device the heap backs for quick testing.

--- a/docs/APIs/storage/filesystem.md
+++ b/docs/APIs/storage/filesystem.md
@@ -1,0 +1,59 @@
+# File System
+
+The filesystem API provides a common interface for implementing a [filesystem](https://en.wikipedia.org/wiki/File_system) on a [block-based storage device](block_device.md). The filesystem API is presented as a class-based interface, but implementing the filesystem API provides the standard POSIX file API familiar to C users.
+
+## Example
+
+Here is what it looks like to use the filesystem in mbed OS:
+
+[FAT filesystem example](https://github.com/armmbed/mbed-os-example-fat-filesystem)
+
+## Declaring a filesystem
+
+The [FileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h) class provides the core API for filesystem operations. A user must provide a BlockDevice to back the filesystem. When a filesystem is declared with a name, files can be opened on the filesystem through standard POSIX functions (see [open](http://pubs.opengroup.org/onlinepubs/009695399/functions/open.html) or [fopen](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fopen.html).
+
+Existing filesystems:
+
+- [FATFileSystem](https://github.com/ARMmbed/mbed-os/tree/master/features/filesystem/fat) - Standard filesystem that has stood the test of time
+
+The [BlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/BlockDevice.h) class provides the underlying API for representing block-based storage that can be used to back a filesystem. mbed OS provides standard interfaces for the more common storage mediums, and the BlockDevice class can be extended to provide support for storage that is not supported.
+
+Existing block devices:
+
+- [SDBlockDevice](https://github.com/armmbed/sd-driver) - Block device for SD cards
+- [SPIFBlockDevice](https://github.com/armmbed/spiflash-driver) - Block device for NOR based SPI flash devices
+- [I2CEEBlockDevice](https://github.com/armmbed/i2ceeprom-driver) - Block device for EEPROM based I2C devices
+- [HeapBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h) - Block device backed by the heap for quick testing
+
+Additionally, two utility block devices are provided for better control over how storage is allocated. The [SlicingBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/SlicingBlockDevice.h) allows a user to partition storage into smaller block devices that can be used independentally, and the [ChainingBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/ChainingBlockDevice.h) allows a user to chain multiple block devices together, extending the usable amount of storage.
+
+Note: Some filesystems may provide a format function for cleanly initializing a filesystem on an underlying block device. However, this is optional and a filesystem may require an external tool to set up the filesystem before the first use.
+
+## C++ classes
+
+The [FileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h) class provides the core user interface, with general functions that map directly to their global POSIX counterparts. mbed OS provides [File](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h) and [Dir](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h) classes that represent files and directories in a C++ API that takes advantage of object oriented features in C++.
+
+To implement a new filesystem in mbed OS, an implementor just needs to provide the abstract functions in the FileSystem interface. The [FATFileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/fat/FATFileSystem.cpp) provides an excellent example, and tests of the POSIX API can be found [here](https://github.com/ARMmbed/sd-driver/tree/master/features/TESTS/filesystem).
+
+Minimal filesystem operations required:
+
+- rename - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/rename.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L75)
+- remove - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/remove.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L67)
+- stat - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/stat.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L83)
+- mkdir - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L91)
+
+Minimal file operations required:
+
+- file open - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L63), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L105)
+- file close - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/close.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L69), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L112)
+- file read - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L78), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L121)
+- file write - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L86), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L130)
+- file seek - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L109), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L157)
+
+Minimal directory operations required:
+
+- dir open - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/opendir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L56), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L186)
+- dir close - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/closedir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L62), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L193)
+- dir read - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/readdir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L70), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L201)
+- dir seek - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/seekdir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L77), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L209)
+

--- a/docs/APIs/storage/filesystem.md
+++ b/docs/APIs/storage/filesystem.md
@@ -1,59 +1,58 @@
-# File System
+# File system
 
-The filesystem API provides a common interface for implementing a [filesystem](https://en.wikipedia.org/wiki/File_system) on a [block-based storage device](block_device.md). The filesystem API is presented as a class-based interface, but implementing the filesystem API provides the standard POSIX file API familiar to C users.
+The file system API provides a common interface for implementing a [file system](https://en.wikipedia.org/wiki/File_system) on a [block-based storage device](block_device.md). The file system API is a class-based interface, but implementing the file system API provides the standard POSIX file API familiar to C users.
 
 ## Example
 
-Here is what it looks like to use the filesystem in mbed OS:
+Here is what it looks like to use the file system in mbed OS:
 
-[FAT filesystem example](https://github.com/armmbed/mbed-os-example-fat-filesystem)
+[FAT file system example](https://github.com/armmbed/mbed-os-example-fat-filesystem)
 
-## Declaring a filesystem
+## Declaring a file system
 
-The [FileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h) class provides the core API for filesystem operations. A user must provide a BlockDevice to back the filesystem. When a filesystem is declared with a name, files can be opened on the filesystem through standard POSIX functions (see [open](http://pubs.opengroup.org/onlinepubs/009695399/functions/open.html) or [fopen](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fopen.html).
+The [FileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h) class provides the core API for file system operations. You must provide a block device to back the file system. When you declare a file system with a name, you can open files on the file system through standard POSIX functions (see [open](http://pubs.opengroup.org/onlinepubs/009695399/functions/open.html) or [fopen](http://pubs.opengroup.org/onlinepubs/9699919799/functions/fopen.html).
 
-Existing filesystems:
+Existing file systems:
 
-- [FATFileSystem](https://github.com/ARMmbed/mbed-os/tree/master/features/filesystem/fat) - Standard filesystem that has stood the test of time
+The [FAT file system](https://github.com/ARMmbed/mbed-os/tree/master/features/filesystem/fat) is a standard file system.
 
-The [BlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/BlockDevice.h) class provides the underlying API for representing block-based storage that can be used to back a filesystem. mbed OS provides standard interfaces for the more common storage mediums, and the BlockDevice class can be extended to provide support for storage that is not supported.
+The [BlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/BlockDevice.h) class provides the underlying API for representing block-based storage that can be used to back a file system. mbed OS provides standard interfaces for the more common storage media, and you can extend the BlockDevice class to provide support for unsupported storage.
 
 Existing block devices:
 
-- [SDBlockDevice](https://github.com/armmbed/sd-driver) - Block device for SD cards
-- [SPIFBlockDevice](https://github.com/armmbed/spiflash-driver) - Block device for NOR based SPI flash devices
-- [I2CEEBlockDevice](https://github.com/armmbed/i2ceeprom-driver) - Block device for EEPROM based I2C devices
-- [HeapBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h) - Block device backed by the heap for quick testing
+- [SDBlockDevice](https://github.com/armmbed/sd-driver) - block device for SD cards.
+- [SPIFBlockDevice](https://github.com/armmbed/spiflash-driver) - block device for NOR based SPI flash devices.
+- [I2CEEBlockDevice](https://github.com/armmbed/i2ceeprom-driver) - block device for EEPROM based I2C devices.
+- [HeapBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/HeapBlockDevice.h) - block device backed by the heap for quick testing.
 
-Additionally, two utility block devices are provided for better control over how storage is allocated. The [SlicingBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/SlicingBlockDevice.h) allows a user to partition storage into smaller block devices that can be used independentally, and the [ChainingBlockDevice](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/ChainingBlockDevice.h) allows a user to chain multiple block devices together, extending the usable amount of storage.
+Additionally, two utility block devices give you better control over how storage is allocated. The [slicing block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/SlicingBlockDevice.h) allows you to partition storage into smaller block devices that you can use independentally, and the [chaining block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/ChainingBlockDevice.h) allows you to chain multiple block devices together and extend the usable amount of storage.
 
-Note: Some filesystems may provide a format function for cleanly initializing a filesystem on an underlying block device. However, this is optional and a filesystem may require an external tool to set up the filesystem before the first use.
+Note: Some file systems may provide a format function for cleanly initializing a file system on an underlying block device or require external tools to set up the file system before the first use.
 
 ## C++ classes
 
-The [FileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h) class provides the core user interface, with general functions that map directly to their global POSIX counterparts. mbed OS provides [File](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h) and [Dir](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h) classes that represent files and directories in a C++ API that takes advantage of object oriented features in C++.
+The [FileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h) class provides the core user interface with general functions that map directly to their global POSIX counterparts. mbed OS provides [File](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h) and [Dir](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h) classes that represent files and directories in a C++ API that uses object-oriented features in C++.
 
-To implement a new filesystem in mbed OS, an implementor just needs to provide the abstract functions in the FileSystem interface. The [FATFileSystem](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/fat/FATFileSystem.cpp) provides an excellent example, and tests of the POSIX API can be found [here](https://github.com/ARMmbed/sd-driver/tree/master/features/TESTS/filesystem).
+To implement a new file system in mbed OS, an implementor just needs to provide the abstract functions in the file system interface. The [FAT file system](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/fat/FATFileSystem.cpp) provides an excellent example, you can find tests of the POSIX API [here](https://github.com/ARMmbed/sd-driver/tree/master/features/TESTS/filesystem).
 
-Minimal filesystem operations required:
+Minimal file system operations required:
 
-- rename - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/rename.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L75)
-- remove - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/remove.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L67)
-- stat - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/stat.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L83)
-- mkdir - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L91)
+- rename - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/rename.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L75).
+- remove - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/remove.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L67).
+- stat - [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/stat.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L83).
+- mkdir - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html), [user/implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L91).
 
 Minimal file operations required:
 
-- file open - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L63), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L105)
-- file close - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/close.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L69), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L112)
-- file read - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L78), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L121)
-- file write - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L86), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L130)
-- file seek - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L109), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L157)
+- file open - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L63), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L105).
+- file close - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/close.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L69), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L112).
+- file read - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L78), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L121).
+- file write - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L86), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L130).
+- file seek - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/lseek.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/File.h#L109), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L157).
 
 Minimal directory operations required:
 
-- dir open - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/opendir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L56), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L186)
-- dir close - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/closedir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L62), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L193)
-- dir read - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/readdir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L70), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L201)
-- dir seek - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/seekdir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L77), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L209)
-
+- dir open - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/opendir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L56), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L186).
+- dir close - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/closedir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L62), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L193).
+- dir read - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/readdir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L70), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L201).
+- dir seek - [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/functions/seekdir.html), [user API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/Dir.h#L77), [implementation API](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/FileSystem.h#L209).

--- a/docs/APIs/storage/storage_index.md
+++ b/docs/APIs/storage/storage_index.md
@@ -1,6 +1,6 @@
 # Storage APIs
 
-Here are the storage APIs present in mbed OS:
+The storage APIs present in mbed OS are:
 
-* [Filesystem](filesystem.md): A common interface for using filesystems on block devices
-* [Block Device](block_device.md): A common interface for block-based storage devices
+* [File system](filesystem.md): a common interface for using file systems on block devices.
+* [Block device](block_device.md): a common interface for block-based storage devices.

--- a/docs/APIs/storage/storage_index.md
+++ b/docs/APIs/storage/storage_index.md
@@ -1,0 +1,6 @@
+# Storage APIs
+
+Here are the storage APIs present in mbed OS:
+
+* [Filesystem](filesystem.md): A common interface for using filesystems on block devices
+* [Block Device](block_device.md): A common interface for block-based storage devices


### PR DESCRIPTION
cc @AnotherButler, @iriark01 

I have some filesystem docs for you. I tried to match the layout of the networking docs (these apis are similar in goals), so let me know if anything is in the wrong place or if anything needs to be just generally improved.

@simonqhughes, adding filesystem documentation to the documentation on the website. Does this look good? Feel free to let me know if you think anything should be improved (also if my used of "block" terminology is reasonable).