### PR TITLE
Add blurb about the MBR and other utility block devices

### DIFF
--- a/docs/APIs/storage/block_device.md
+++ b/docs/APIs/storage/block_device.md
@@ -30,11 +30,11 @@ As a rule of thumb, you can use the erase size for applications that use a singl
 
 ## Utility block devices
 
-mbed OS contains several utility block devices to give you better control over how storage is allocated.
+mbed OS contains several utility block devices to give you better control over the allocation of storage.
 
-- The [slicing block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/SlicingBlockDevice.h) allows you to partition storage into smaller block devices that you can use independentally.
-- The [chaining block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/ChainingBlockDevice.h) allows you to chain multiple block devices together and extend the usable amount of storage.
-- The [MBR block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/MBRBlockDevice.h) allows you to partition storage with a [Master Boot Record](https://en.wikipedia.org/wiki/Master_boot_record). The MBR allows the partitions to be configured seperately from outside the application.
+- With the [slicing block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/SlicingBlockDevice.h), you can partition storage into smaller block devices that you can use independentally.
+- With the [chaining block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/ChainingBlockDevice.h), you can chain multiple block devices together and extend the usable amount of storage.
+- mbed OS comes with support for storing partitions on disk with a [Master Boot Record (MBR)](https://en.wikipedia.org/wiki/Master_boot_record). The [MBR block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/MBRBlockDevice.h) provides this functionality and supports creating partitions at runtime or using preformatted partitions configured separately from outside the application.
 
 ## Example block devices
 

--- a/docs/APIs/storage/block_device.md
+++ b/docs/APIs/storage/block_device.md
@@ -28,6 +28,14 @@ Block devices indicate their block sizes through the `get_read_size`, `get_progr
 
 As a rule of thumb, you can use the erase size for applications that use a single block size (for example, the FAT file system).
 
+## Utility block devices
+
+mbed OS contains several utility block devices to give you better control over how storage is allocated.
+
+- The [slicing block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/SlicingBlockDevice.h) allows you to partition storage into smaller block devices that you can use independentally.
+- The [chaining block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/ChainingBlockDevice.h) allows you to chain multiple block devices together and extend the usable amount of storage.
+- The [MBR block device](https://github.com/ARMmbed/mbed-os/blob/master/features/filesystem/bd/MBRBlockDevice.h) allows you to partition storage with a [Master Boot Record](https://en.wikipedia.org/wiki/Master_boot_record). The MBR allows the partitions to be configured seperately from outside the application.
+
 ## Example block devices
 
 - [SDBlockDevice](https://github.com/armmbed/sd-driver) - Block device for SD cards.


### PR DESCRIPTION
This is a part of documenting the MBR block device that is coming into mbed OS:
https://github.com/ARMmbed/mbed-os/pull/3936

Note: This is dependeny on the above pr. That pr looks like it may not make it in until 5.6, so this pr may need to be rebased when a new docs branch is created.

cc @AnotherButler 

## NOTE: WAIT TO MERGE UNTIL 5.5