### PR TITLE
Reinstate links which transclude doxygen API pages

### DIFF
--- a/docs/APIs/io/AnalogIn.md
+++ b/docs/APIs/io/AnalogIn.md
@@ -1,6 +1,6 @@
 # AnalogIn
 
-Use the AnalogIn API to read an external voltage applied to an analog input pin. 
+Use the AnalogIn class to read an external voltage applied to an analog input pin. 
 
 **Tips:**
 
@@ -9,7 +9,7 @@ Use the AnalogIn API to read an external voltage applied to an analog input pin.
 
 ## API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/AnalogIn_8h_source.html) 
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classmbed_1_1AnalogIn.html) 
 
 ## Hello World!
 

--- a/docs/APIs/io/AnalogOut.md
+++ b/docs/APIs/io/AnalogOut.md
@@ -1,6 +1,6 @@
 # AnalogOut
 
-Use the AnalogOut interface to set the voltage of an analog output pin in the range of VSS to VCC.
+Use the AnalogOut class to set the voltage of an analog output pin in the range of VSS to VCC.
 
 **Tips:**
 
@@ -10,7 +10,7 @@ Use the AnalogOut interface to set the voltage of an analog output pin in the ra
 
 ## API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/AnalogOut_8h_source.html) 
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classmbed_1_1AnalogOut.html) 
 
 ## Hello World!
 

--- a/docs/APIs/io/BusIn.md
+++ b/docs/APIs/io/BusIn.md
@@ -1,6 +1,6 @@
 #BusIn
 
-Use the BusIn interface to create a number of DigitalIn pins that can be read as one value.
+Use the BusIn class to create a number of DigitalIn pins that can be read as one value.
 
 You can use any of the numbered mbed pins as a DigitalIn in the BusIn. 
 

--- a/docs/APIs/io/BusInOut.md
+++ b/docs/APIs/io/BusInOut.md
@@ -1,6 +1,6 @@
 #BusInOut
 
-Use the BusInOut interface as a bidirectional bus that collects a number of [DigitalInOut](DigitalInOut.md) pins that can be read and written as one value.
+Use the BusInOut class as a bidirectional bus that collects a number of [DigitalInOut](DigitalInOut.md) pins that can be read and written as one value.
 
 You can use any of the numbered mbed pins as a [DigitalInOut](DigitalInOut.md). 
 

--- a/docs/APIs/io/BusOut.md
+++ b/docs/APIs/io/BusOut.md
@@ -1,6 +1,6 @@
 # BusOut
 
-Use the BusOut interface to create a number of [DigitalOut](DigitalOut.md) pins that you can write as one value.
+Use the BusOut class to create a number of [DigitalOut](DigitalOut.md) pins that you can write as one value.
 
 ## API
 

--- a/docs/APIs/io/DigitalIn.md
+++ b/docs/APIs/io/DigitalIn.md
@@ -1,6 +1,6 @@
 #DigitalIn
 
-Use the DigitalIn interface to read the value of a digital input pin.
+Use the DigitalIn class to read the value of a digital input pin.
 
 You can use any of the numbered mbed pins can be used as a DigitalIn. 
 

--- a/docs/APIs/io/DigitalInOut.md
+++ b/docs/APIs/io/DigitalInOut.md
@@ -1,6 +1,6 @@
 # DigitalInOut
 
-Use the DigitalInOut interface as a bidirectional digital pin:
+Use the DigitalInOut class as a bidirectional digital pin:
 
 * Read the value of a digital pin when set as an input.
 * Write the value when set as an output.

--- a/docs/APIs/io/DigitalOut.md
+++ b/docs/APIs/io/DigitalOut.md
@@ -1,6 +1,6 @@
 # DigitalOut
 
-Use the DigitalOut interface to configure and control a digital output pin. 
+Use the DigitalOut class to configure and control a digital output pin. 
 
 ## API
 

--- a/docs/APIs/io/InterruptIn.md
+++ b/docs/APIs/io/InterruptIn.md
@@ -1,10 +1,10 @@
 # InterruptIn
 
-Use the InterruptIn interface to trigger an event when a [digital input pin](DigitalIn.md) changes.
+Use the InterruptIn class to trigger an event when a [digital input pin](DigitalIn.md) changes.
 
 ## API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/InterruptIn_8h_source.html) 
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classmbed_1_1InterruptIn.html) 
 
 **Warnings:**
 

--- a/docs/APIs/io/PortIn.md
+++ b/docs/APIs/io/PortIn.md
@@ -1,12 +1,12 @@
 # PortIn
 
-Use the PortIn interface to read an underlying GPIO port as one value. This is much faster than [BusIn](BusIn.md) because you can read a port in one go, but it is much less flexible because you are constrained by the port and bit layout of the underlying GPIO ports.
+Use the PortIn class to read an underlying GPIO port as one value. This is much faster than [BusIn](BusIn.md) because you can read a port in one go, but it is much less flexible because you are constrained by the port and bit layout of the underlying GPIO ports.
 
-A mask can be supplied so only certain bits of a port are used, allowing other bits to be used for other interfaces. 
+A mask can be supplied so only certain bits of a port are used, allowing other bits to be used for other classes. 
 
 ## API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/PortIn_8h_source.html) 
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classmbed_1_1PortIn.html) 
 
 ## Hello World!
 

--- a/docs/APIs/io/PortInOut.md
+++ b/docs/APIs/io/PortInOut.md
@@ -1,12 +1,12 @@
 # PortInOut
 
-Use the PortInOut interface to read and write an underlying GPIO port as one value. This is much faster than [BusInOut](BusInOut.md) because you can write a port in one go, but it is much less flexible because you are constrained by the port and bit layout of the underlying GPIO ports.
+Use the PortInOut class to read and write an underlying GPIO port as one value. This is much faster than [BusInOut](BusInOut.md) because you can write a port in one go, but it is much less flexible because you are constrained by the port and bit layout of the underlying GPIO ports.
 
-A mask can be supplied so only certain bits of a port are used, allowing other bits to be used for other interfaces. 
+A mask can be supplied so only certain bits of a port are used, allowing other bits to be used for other classes. 
 
 ## API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/PortInOut_8h_source.html) 
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classmbed_1_1PortInOut.html) 
 
 ## Hello World!
 

--- a/docs/APIs/io/PortOut.md
+++ b/docs/APIs/io/PortOut.md
@@ -1,12 +1,12 @@
 # PortOut
 
-Use the PortOut interface to write to an underlying GPIO port as one value. This is much faster than [BusOut](BusOut.md) because you can write a port in one go, but it is much less flexible because you are constrained by the port and bit layout of the underlying GPIO ports.
+Use the PortOut class to write to an underlying GPIO port as one value. This is much faster than [BusOut](BusOut.md) because you can write a port in one go, but it is much less flexible because you are constrained by the port and bit layout of the underlying GPIO ports.
 
-A mask can be supplied so only certain bits of a port are used, allowing other bits to be used for other interfaces. 
+A mask can be supplied so only certain bits of a port are used, allowing other bits to be used for other classes. 
 
 ## API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/PortOut_8h_source.html) 
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classmbed_1_1PortOut.html) 
 
 ## Hello World!
 

--- a/docs/APIs/io/PwmOut.md
+++ b/docs/APIs/io/PwmOut.md
@@ -1,10 +1,14 @@
 # PwmOut
 
-Use the PwmOut interface to control the frequency and mark-to-space ratio of a digital pulse train.
+Use the PwmOut class to control the period and pulse width (duty cycle) of digital signal.
+
+**Tips:**
+
+* For more information on what can be done using pulse width modulation, see [https://en.wikipedia.org/wiki/Pulse-width_modulation](https://en.wikipedia.org/wiki/Pulse-width_modulation).   
 
 ## API
 
-[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/PwmOut_8h_source.html) 
+[![View code](https://www.mbed.com/embed/?type=library)](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classmbed_1_1PwmOut.html) 
 
 
 ## Hello World!
@@ -17,13 +21,13 @@ This code example uses the default period of 0.020s and ramps the duty cycle fro
 
 The default period is 0.020s, and the default pulse width is 0.
 
-The PwmOut interface can express the pulse train in many ways to fit different use cases. You can express the period and pulse width directly in units of seconds, millisecond or microseconds. You can also express the pulse width as a percentage of the the period.
+The PwmOut class can express the pulse width in many ways to fit different use cases. You can express the period and pulse width directly in units of seconds, millisecond or microseconds. You can also express the pulse width as a percentage of the the period.
   
 ## Code Examples
 
 ### Example one
 
-This code example sets the period in seconds and the duty cycle as a percentage of the period in floating point (range: 0 to 1). The effect of this code snippet will be to blink LED2 over a four-second cycle, 50% on, for a pattern of two seconds on, two seconds off.
+This code example sets the period in seconds and the duty cycle as a percentage of the period in floating point (range: 0.0f to 1.0f). The effect of this code snippet will be to blink LED2 over a four-second cycle, 50% on, for a pattern of two seconds on, two seconds off.
 
 [![View code](https://www.mbed.com/embed/?url=https://developer.mbed.org/teams/mbed_example/code/PwmOut_ex_1/)](https://developer.mbed.org/teams/mbed_example/code/PwmOut_ex_1/file/07220dd760cc/main.cpp)
 
@@ -35,6 +39,6 @@ The following example does the same thing, but instead of specifying the duty cy
 
 ### Example three
 
-This code example is for an RC Servo. In RC Servos you set the position based on the PWM signal's duty cycle or pulse width. This example code uses a period of 0.020s and increases the pulse width by 0.0001s on each pass. This will cause an increase of .5% of the servo's range every .25s. In effect the servo will move 2% of its range per second, meaning after 50 seconds the servo will have gone from 0% to 100% of its range. 
+This code example is for an RC Servo. In RC Servos you set the position based on the PWM signal's pulse width or duty cycle. This example code uses a period of 0.020s and increases the pulse width by 0.0001s on each pass. This will cause an increase of 0.5% of the servo's range every 0.25s. In effect the servo will move 2% of its range per second, meaning after 50 seconds the servo will have gone from 0% to 100% of its range. 
 
 [![View code](https://www.mbed.com/embed/?url=https://developer.mbed.org/teams/mbed_example/code/PwmOut_ex_3/)](https://developer.mbed.org/teams/mbed_example/code/PwmOut_ex_3/file/465d882e6939/main.cpp)

--- a/docs/APIs/io/inputs_outputs.md
+++ b/docs/APIs/io/inputs_outputs.md
@@ -1,6 +1,6 @@
 # Handling inputs and outputs
 
-Inputs and outputs on development boards are either analog or digital.
+Inputs and outputs on microcontrollers are either analog or digital.
 
 ## Analog I/O
 


### PR DESCRIPTION
Other corrections:
- class used rather than interface for an API which has an
implementation that is expected to be used.
- PWM frequency, period, pulse width, pulse train, duty cycle
unification of usage