### PR TITLE
Update NSAPI error codes

### DIFF
--- a/docs/APIs/communication/network_sockets.md
+++ b/docs/APIs/communication/network_sockets.md
@@ -36,26 +36,33 @@ Use the [SocketAddress](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/ap
 The convention of the network-socket API is for functions to return negative error codes to indicate failure. On success, a function may return zero or a non-negative integer to indicate the size of a transaction. On failure, a function must return a negative integer, which should be one of the error codes in the `nsapi_error_t` enum ([here](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/group__netsocket.html#gac21eb8156cf9af198349069cdc7afeba)):
 
 ``` cpp
-/** Enum of standardized error codes 
+/** Enum of standardized error codes
  *
  *  Valid error codes have negative values and may
  *  be returned by any network operation.
  *
- *  @enum nsapi_error_t
+ *  @enum nsapi_error
  */
-typedef enum nsapi_error {
-    NSAPI_ERROR_WOULD_BLOCK   = -3001,     /*!< data is not available but call is nonblocking */
-    NSAPI_ERROR_UNSUPPORTED   = -3002,     /*!< unsupported functionality */
-    NSAPI_ERROR_PARAMETER     = -3003,     /*!< invalid configuration */
-    NSAPI_ERROR_NO_CONNECTION = -3004,     /*!< not connected to a network */
-    NSAPI_ERROR_NO_SOCKET     = -3005,     /*!< socket not available for use */
-    NSAPI_ERROR_NO_ADDRESS    = -3006,     /*!< IP address is not known */
-    NSAPI_ERROR_NO_MEMORY     = -3007,     /*!< memory resource not available */
-    NSAPI_ERROR_DNS_FAILURE   = -3008,     /*!< DNS failed to complete successfully */
-    NSAPI_ERROR_DHCP_FAILURE  = -3009,     /*!< DHCP failed to complete successfully */
-    NSAPI_ERROR_AUTH_FAILURE  = -3010,     /*!< connection to access point failed */
-    NSAPI_ERROR_DEVICE_ERROR  = -3011,     /*!< failure interfacing with the network processor */
-} nsapi_error_t;
+enum nsapi_error {
+    NSAPI_ERROR_OK                  =  0,        /*!< no error */
+    NSAPI_ERROR_WOULD_BLOCK         = -3001,     /*!< no data is not available but call is non-blocking */
+    NSAPI_ERROR_UNSUPPORTED         = -3002,     /*!< unsupported functionality */
+    NSAPI_ERROR_PARAMETER           = -3003,     /*!< invalid configuration */
+    NSAPI_ERROR_NO_CONNECTION       = -3004,     /*!< not connected to a network */
+    NSAPI_ERROR_NO_SOCKET           = -3005,     /*!< socket not available for use */
+    NSAPI_ERROR_NO_ADDRESS          = -3006,     /*!< IP address is not known */
+    NSAPI_ERROR_NO_MEMORY           = -3007,     /*!< memory resource not available */
+    NSAPI_ERROR_NO_SSID             = -3008,     /*!< ssid not found */
+    NSAPI_ERROR_DNS_FAILURE         = -3009,     /*!< DNS failed to complete successfully */
+    NSAPI_ERROR_DHCP_FAILURE        = -3010,     /*!< DHCP failed to complete successfully */
+    NSAPI_ERROR_AUTH_FAILURE        = -3011,     /*!< connection to access point failed */
+    NSAPI_ERROR_DEVICE_ERROR        = -3012,     /*!< failure interfacing with the network processor */
+    NSAPI_ERROR_IN_PROGRESS         = -3013,     /*!< operation (eg connect) in progress */
+    NSAPI_ERROR_ALREADY             = -3014,     /*!< operation (eg connect) already in progress */
+    NSAPI_ERROR_IS_CONNECTED        = -3015,     /*!< socket is already connected */
+    NSAPI_ERROR_CONNECTION_LOST     = -3016,     /*!< connection lost */
+    NSAPI_ERROR_CONNECTION_TIMEOUT  = -3017,     /*!< connection timed out */
+};
 ```
 
 ## Nonblocking operation


### PR DESCRIPTION
The error codes in the current doc are outdated. This was pointed out in a developer site question - https://developer.mbed.org/questions/78652/mbed-5-network-sockets-return-code-3012/#answer13100. The current valid return codes can be found in [this file](https://github.com/ARMmbed/mbed-os/blob/master/features/netsocket/nsapi_types.h#L37).

@AnotherButler 