### PR TITLE
broken link on wifi.md

### DIFF
--- a/docs/APIs/communication/wifi.md
+++ b/docs/APIs/communication/wifi.md
@@ -1,6 +1,6 @@
 # Wi-Fi
 
-The [WifiInterface](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classWiFiInterface.html ) provides a simple C++ API for connecting to the internet over a Wi-Fi device.
+The [WifiInterface](https://docs.mbed.com/docs/mbed-os-api/en/latest/api/classWiFiInterface.html) provides a simple C++ API for connecting to the internet over a Wi-Fi device.
 
 There are multiple Wi-Fi components that implement the WiFiInterface class. For the example below,
 the [ESP8266Interface](https://github.com/armmbed/esp8266-driver) is used.

--- a/docs/APIs/communication/wifi.md
+++ b/docs/APIs/communication/wifi.md
@@ -1,6 +1,6 @@
 # Wi-Fi
 
-The [WifiInterface](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classWiFiInterface.html) provides a simple C++ API for connecting to the internet over a Wi-Fi device.
+The [WifiInterface](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classWiFiInterface.html ) provides a simple C++ API for connecting to the internet over a Wi-Fi device.
 
 There are multiple Wi-Fi components that implement the WiFiInterface class. For the example below,
 the [ESP8266Interface](https://github.com/armmbed/esp8266-driver) is used.


### PR DESCRIPTION
The link to the WifiInterface API documentation is broken at the top of the page.  You can find an API doc for WifiInterface through the search box at the following location: https://docs.mbed.com/docs/vignesh/en/latest/api/classWiFiInterface.html

but I am not sure if this is the correct doc.