### PR TITLE
broken link on ethernet.md

### DIFF
--- a/docs/APIs/communication/ethernet.md
+++ b/docs/APIs/communication/ethernet.md
@@ -1,6 +1,6 @@
 # Ethernet
 
-The [EthernetInterface](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classEthernetInterface.html) provides a C++ API for connecting to the internet over an Ethernet connection.
+The [EthernetInterface](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classEthernetInterface.html ) provides a C++ API for connecting to the internet over an Ethernet connection.
 
 ## API 
 

--- a/docs/APIs/communication/ethernet.md
+++ b/docs/APIs/communication/ethernet.md
@@ -1,6 +1,6 @@
 # Ethernet
 
-The [EthernetInterface](https://docs.mbed.com/docs/mbed-os-api/en/mbed-os-5.5/api/classEthernetInterface.html ) provides a C++ API for connecting to the internet over an Ethernet connection.
+The [EthernetInterface](https://docs.mbed.com/docs/mbed-os-api/en/latest/api/classEthernetInterface.html) provides a C++ API for connecting to the internet over an Ethernet connection.
 
 ## API 
 


### PR DESCRIPTION
The link to the EthernetInterface API documentation is broken at the top of the page.